### PR TITLE
fix(workflow): inject GH_TOKEN into remote URL for push auth; bump checkout@v5

### DIFF
--- a/.github/workflows/get_chn_ip.yml
+++ b/.github/workflows/get_chn_ip.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # PAT used for the write-back push; see CHNIP_GIT_KEY repo secret.
           token: ${{ secrets.CHNIP_GIT_KEY }}
@@ -42,10 +42,17 @@ jobs:
       - name: Update IP files
         env:
           TZ: Asia/Shanghai
+          GH_TOKEN: ${{ secrets.CHNIP_GIT_KEY }}
         run: |
           set -euo pipefail
           git config --local user.email "mayax@github.com"
           git config --local user.name  "mayaxcn"
+
+          # Inject the PAT into the remote URL so `git push` can authenticate.
+          # `x-access-token` is the username convention for GitHub PATs (works for
+          # both classic and fine-grained tokens). The token never appears in the
+          # URL of any committed file.
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/mayaxcn/china-ip-list.git"
 
           BIN="$(pwd)/bin/Release/net7.0"
           cp "${BIN}/chn_ip.txt"      chn_ip.txt


### PR DESCRIPTION
## 修复 #6062 失败

### 错误

[Run #6062](https://github.com/mayaxcn/china-ip-list/actions/runs/34457587210) 失败，日志：

```
could not read Username for 'https://github.com': terminal prompts disabled
The process '/usr/bin/git' failed with exit code 128
```

### 根因

上一版 workflow 把 `actions/checkout@v4` 配上了 `token: ${{ secrets.CHNIP_GIT_KEY }}`，但默认的 checkout 行为**不会**把 token 自动注入到 remote URL（公开仓库）。后续 `git push origin master` 时没有凭据，git 试图交互式询问用户名，Actions runner 默认禁止交互式输入，于是 128 退出。

### 修复

在 push 前显式把 token 注入 remote URL：

```bash
git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/mayaxcn/china-ip-list.git"
```

- `x-access-token` 是 GitHub PAT 推荐的 username（兼容 classic 和 fine-grained）
- token 只存在于 runner 进程环境变量，**不会**写进任何 commit 文件
- 这步是原 PR #7 里漏了的，抱歉

### 顺手修

- `actions/checkout@v4` → `@v5`：消除 Node.js 20 deprecation warning（GitHub 2025-09-19 起强制要求 Node 24）
- 增加注释说明 token 处理逻辑

### 验证清单

- [ ] merge 后看下一次 `schedule` cron（UTC 16:00 / CST 00:00）或手动 `workflow_dispatch` 触发
- [ ] 确认 push 步骤成功（exit 0）且 commit message 含 CST 时间
- [ ] 确认 Node 20 warning 消失

### 风险评估

| 风险 | 评估 |
|---|---|
| push 仍失败 | 极低：`x-access-token` 是 GitHub 官方认证方式 |
| Token 泄露 | 无：URL 仅在 runner 进程内构造，不入 commit |
| 触发循环 | 无：PAT push 不触发 workflow（与 GITHUB_TOKEN 区分） |

🤖 由 OpenClaw Agent 协助生成