### PR TITLE
rollback: restore workflow to 1b86c6a version, keep Program.cs from #7

### DIFF
--- a/.github/workflows/get_chn_ip.yml
+++ b/.github/workflows/get_chn_ip.yml
@@ -1,69 +1,67 @@
 name: chn-ip-task
 
 on:
-  push:
+  push: # push触发
     branches: [ master ]
-  workflow_dispatch:
-  schedule:
-    # UTC 00:00 / 08:00 / 16:00  (CST 08:00 / 16:00 / 00:00).
-    # Public repos on GitHub Actions can't trigger more often than every 5 min.
-    - cron: '0 */8 * * *'
-
-concurrency:
-  group: chn-ip
-  cancel-in-progress: false
-
-permissions:
-  contents: write
+  workflow_dispatch: # 手动触发
+  schedule: # 计划任务触发
+    - cron: '0 */8 * * *' # cron表达式，Actions时区是UTC时间
 
 jobs:
-  refresh:
+  run-get-ip-list:
+
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-
+    
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          # PAT used for the write-back push; see CHNIP_GIT_KEY repo secret.
-          token: ${{ secrets.CHNIP_GIT_KEY }}
+    # 检出代码
+    - name: Checkout
+      uses: actions/checkout@v3
+      
+    # 设置服务器时区为东八区 
+    - name: Set time zone
+      run: sudo timedatectl set-timezone 'Asia/Shanghai'
+      
+    # 设置 .NET 环境
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 7.0  # 使用已发布的稳定版本
 
-      - name: Setup .NET 7
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 7.0.x
+    # 设置全球化不变模式
+    - name: Set globalization invariant mode
+      run: echo "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1" >> $GITHUB_ENV
 
-      - name: Build
-        run: dotnet build --configuration Release
+    # 恢复依赖
+    - name: Install dependencies
+      run: dotnet restore
+      
+    # 构建应用
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+       
+    # 运行应用
+    - name: Run
+      run: dotnet run --project china_ip_list.csproj
 
-      - name: Run
-        run: dotnet run --project china_ip_list.csproj --configuration Release
-
-      - name: Update IP files
-        env:
-          TZ: Asia/Shanghai
-          GH_TOKEN: ${{ secrets.CHNIP_GIT_KEY }}
-        run: |
-          set -euo pipefail
-          git config --local user.email "mayax@github.com"
-          git config --local user.name  "mayaxcn"
-
-          # Inject the PAT into the remote URL so `git push` can authenticate.
-          # `x-access-token` is the username convention for GitHub PATs (works for
-          # both classic and fine-grained tokens). The token never appears in the
-          # URL of any committed file.
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/mayaxcn/china-ip-list.git"
-
-          BIN="$(pwd)/bin/Release/net7.0"
-          cp "${BIN}/chn_ip.txt"      chn_ip.txt
-          cp "${BIN}/chnroute.txt"    chnroute.txt
-          cp "${BIN}/chn_ip_v6.txt"   chn_ip_v6.txt
-          cp "${BIN}/chnroute_v6.txt" chnroute_v6.txt
-
-          git add chn_ip.txt chnroute.txt chn_ip_v6.txt chnroute_v6.txt
-          if git diff --cached --quiet; then
-            echo "No changes since last run."
-            exit 0
-          fi
-          git commit -m "chore: refresh CN IP list ($(date '+%Y-%m-%d %H:%M:%S %Z'))"
-          git push origin master
+    # 提交更改到本地
+    - name: Commit files
+      run: |
+         git config --local user.email "mayax@github.com"
+         git config --local user.name "mayaxcn"
+         ls
+         pwd
+         git rm -f chn_ip.txt chnroute.txt chn_ip_v6.txt chnroute_v6.txt
+         git commit -m "删除旧有IP文件!"
+         cp /home/runner/work/china-ip-list/china-ip-list/bin/Debug/net7.0/chn_ip.txt chn_ip.txt
+         cp /home/runner/work/china-ip-list/china-ip-list/bin/Debug/net7.0/chnroute.txt chnroute.txt
+         cp /home/runner/work/china-ip-list/china-ip-list/bin/Debug/net7.0/chn_ip_v6.txt chn_ip_v6.txt
+         cp /home/runner/work/china-ip-list/china-ip-list/bin/Debug/net7.0/chnroute_v6.txt chnroute_v6.txt
+         git add chn_ip.txt chnroute.txt chn_ip_v6.txt chnroute_v6.txt
+         git commit -m "提交新的IP文件，更新于$(date "+%Y-%m-%d %H:%M:%S")"
+         
+    # 推送到远程
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+         github_token: ${{ secrets.CHNIP_GIT_KEY }}
+         branch: master


### PR DESCRIPTION
## 背景

PR #7 和 #8 都在 `git push` 步骤失败。用户决定**回滚 workflow 到 1b86c6a 的版本**（原版 production 已验证过可用），同时**保留 Program.cs 的改进**（PR #7 引入的 HTTPS、async、StringBuilder、`BitOperations`、重试等）。

## 改动范围

- ✅ **回滚** `.github/workflows/get_chn_ip.yml` → 严格按 1b86c6a blob sha `9e397cae9b426705906d1466cd5ac71546141c8f`
- ❌ **保留** `Program.cs`（PR #7 的改进版，未动）
- ❌ **保留** `README.md`、`LICENSE`、`empty_gfw_list.conf`（PR #7 改动）

## 文件 diff

只 1 个文件：`.github/workflows/get_chn_ip.yml`。

主要差异（恢复点）：

| 项 | #8 版本 | 1b86c6a 恢复版 |
|---|---|---|
| checkout | `@v5` + PAT token | `@v3`（无 token） |
| push | `git remote set-url` + `git push` | `ad-m/github-push-action@master` + `github_token` |
| concurrency / timeout / permissions | 已加 | 移除 |
| 北京时间 commit message | 已加 | 还原旧版 UTC + 双 commit 模式 |

## Program.cs 兼容性确认

原版 workflow 用 `dotnet run`（默认 Debug）→ 输出到 `bin/Debug/net7.0/`，cp 路径写死 `/Debug/net7.0/`。
PR #7 改进版 Program.cs 不依赖任何构建配置，只读 APNIC 数据并写文件，**对 Debug/Release 无差异**。

所以回滚 workflow 不会让 Program.cs 跑出不同结果。

## 验证清单

- [ ] 合并后下一次 cron（UTC 16:00 / CST 00:00）或手动 `workflow_dispatch`
- [ ] workflow 完整通过（不再 4 errors）
- [ ] 产生预期的 `chore: refresh CN IP list (...)` commit 或保留旧版双 commit 模式

## 后续

这次让我学到：**不在自己机器上跑过、没真实验证过的"应该 work"的修复，不应该一口气推给用户**。下次类似的 PR 我会先在分支上确认一次 `workflow_dispatch` 通过再请用户合并。

🤖 由 OpenClaw Agent 协助生成